### PR TITLE
Add Button Component for Bracquet

### DIFF
--- a/Bracquet Unit Tests/Utils/HexColorsTests.swift
+++ b/Bracquet Unit Tests/Utils/HexColorsTests.swift
@@ -22,7 +22,7 @@ final class HexColorsTests: XCTestCase {
         expectedBlue = 0
         expectedOpacity = 1
         
-        var (actualOpacity, actualRed, actualGreen, actualBlue) = convertHexToRGBA(hexString: BraquetColors.pureBlack)
+        var (actualOpacity, actualRed, actualGreen, actualBlue) = convertHexToRGBA(hexString: BraquetColors.pureBlack.rawValue)
         
         XCTAssertEqual(actualOpacity, expectedOpacity)
         XCTAssertEqual(actualGreen, expectedGreen)
@@ -35,7 +35,7 @@ final class HexColorsTests: XCTestCase {
         expectedBlue = 204 / 255
         expectedOpacity = 1
         
-        (actualOpacity, actualRed, actualGreen, actualBlue) = convertHexToRGBA(hexString: BraquetColors.primaryBlue)
+        (actualOpacity, actualRed, actualGreen, actualBlue) = convertHexToRGBA(hexString: BraquetColors.primaryBlue.rawValue)
         
         XCTAssertEqual(actualOpacity, expectedOpacity)
         XCTAssertEqual(actualGreen, expectedGreen)

--- a/Bracquet Unit Tests/Views/ButtonViewTests.swift
+++ b/Bracquet Unit Tests/Views/ButtonViewTests.swift
@@ -1,0 +1,84 @@
+//  ButtonViewTests.swift
+//  Copyright 2024 Bracquet
+//
+//  This file contains the UI Unit tests for the Button View
+//
+//  Created by Drew Curtin on 8/30/24.
+
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import Bracquet
+
+
+//      - Constructor test: callback passed successfully, works MUST
+//      - Frame should be 50 pixels no matter what MAYBE
+
+final class ButtonViewTests: XCTestCase {
+    var expectedText: String?
+    var expectedColorType: BraquetColors?
+    
+    override func setUpWithError() throws {
+        expectedText = "Click Me!"
+        expectedColorType = BraquetColors.primaryGreen
+    }
+    
+    override func tearDownWithError() throws {
+        expectedText = nil
+        expectedColorType = nil
+    }
+    
+    func test_constructor_text_sets_button_display_text() throws {
+        // Test that the text string passed to the button constructor gets rendered as the button's display text        
+        let buttonView = ButtonView(text: expectedText!, color: expectedColorType!) {}
+        
+        let buttonText = try buttonView.inspect().find(text: expectedText!)
+        XCTAssertNotNil(buttonText) // The above line will throw if it returns no views, so this is a sufficient check
+    }
+    
+    func test_button_display_text_has_custom_font() throws {
+        // Test that the text displayed by the button has its custom font correct applied ("Inter-SemiBold")
+        let expectedFontName = "Inter-SemiBold"
+        
+        let buttonView = ButtonView(text: expectedText!, color: expectedColorType!) {}
+        
+        let buttonText = try buttonView.inspect().find(text: expectedText!)
+        let buttonTextFontName = try buttonText.attributes().font().name();
+        XCTAssertEqual(buttonTextFontName, expectedFontName)
+    }
+    
+    func test_constructor_color_sets_button_display_color() throws {
+        // Test that the color passed to the button constructor is used to color the button
+        let expectedColor = Color(hex: expectedColorType!.rawValue)
+        let buttonView = ButtonView(text: expectedText!, color: expectedColorType!) {}
+        
+        let button = try buttonView.inspect().find(button: expectedText!)
+        let buttonColor = try button.find(ViewType.HStack.self).background(0).color(0).value()
+        XCTAssertEqual(buttonColor, expectedColor)
+    }
+    
+    func test_constructor_closure_sets_button_tap_behavior() throws {
+        // Test that the closure passed to the button constructor drives the tap behavior of the button
+        var testState: Bool = false
+        
+        let buttonView = ButtonView(text: expectedText!, color: expectedColorType!) {
+            testState.toggle()
+        }
+        
+        let button = try buttonView.inspect().button()
+        try button.tap()
+        XCTAssertTrue(testState)
+        try button.tap()
+        XCTAssertFalse(testState)
+    }
+    
+    func test_button_height_is_static() throws {
+        // Test that the height of the button is always a static value (50 pixels)
+        let expectedHeight: CGFloat = 50
+        
+        let buttonView = ButtonView(text: expectedText!, color: expectedColorType!) {}
+        
+        let buttonHeight = try buttonView.inspect().find(ViewType.HStack.self).fixedHeight()
+        XCTAssertEqual(buttonHeight, expectedHeight)
+    }
+}

--- a/Bracquet Unit Tests/Views/HeaderViewTests.swift
+++ b/Bracquet Unit Tests/Views/HeaderViewTests.swift
@@ -58,7 +58,7 @@ final class HeaderViewTests: XCTestCase {
     
     func test_title_has_black_font_color() throws {
         // When the title is rendered, it should have a pure black font color (#000000)
-        let expectedColor = Color(hex: BraquetColors.pureBlack)
+        let expectedColor = Color(hex: BraquetColors.pureBlack.rawValue)
         let hStack = try headerView.inspect().hStack()
         
         let titleFontColor = try hStack.text(2).attributes().foregroundColor()

--- a/Bracquet.xcodeproj/project.pbxproj
+++ b/Bracquet.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		47B65C452C6EABFE00F8076B /* HeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B65C442C6EABFE00F8076B /* HeaderViewTests.swift */; };
 		47B65C4D2C6EAD5700F8076B /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = 47B65C4C2C6EAD5700F8076B /* ViewInspector */; };
 		47B65C502C6FFE2F00F8076B /* HexColorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B65C4F2C6FFE2F00F8076B /* HexColorsTests.swift */; };
+		47B65C532C7EA2AE00F8076B /* ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B65C522C7EA2AE00F8076B /* ButtonView.swift */; };
+		47B65C552C82660700F8076B /* ButtonViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B65C542C82660700F8076B /* ButtonViewTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +78,8 @@
 		47B65C422C6EABFE00F8076B /* Bracquet-Unit-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Bracquet-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		47B65C442C6EABFE00F8076B /* HeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderViewTests.swift; sourceTree = "<group>"; };
 		47B65C4F2C6FFE2F00F8076B /* HexColorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexColorsTests.swift; sourceTree = "<group>"; };
+		47B65C522C7EA2AE00F8076B /* ButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonView.swift; sourceTree = "<group>"; };
+		47B65C542C82660700F8076B /* ButtonViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonViewTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +145,7 @@
 			isa = PBXGroup;
 			children = (
 				476040DC2C69A7DA004D3223 /* HeaderView.swift */,
+				47B65C522C7EA2AE00F8076B /* ButtonView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -192,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				47B65C442C6EABFE00F8076B /* HeaderViewTests.swift */,
+				47B65C542C82660700F8076B /* ButtonViewTests.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -330,6 +336,7 @@
 			files = (
 				476040CF2C69A6F6004D3223 /* BracquetApp.swift in Sources */,
 				476040DF2C69A7F9004D3223 /* HexColors.swift in Sources */,
+				47B65C532C7EA2AE00F8076B /* ButtonView.swift in Sources */,
 				476040DD2C69A7DA004D3223 /* HeaderView.swift in Sources */,
 				47B65C3D2C6EA76800F8076B /* Styles.swift in Sources */,
 			);
@@ -341,6 +348,7 @@
 			files = (
 				47B65C452C6EABFE00F8076B /* HeaderViewTests.swift in Sources */,
 				47B65C502C6FFE2F00F8076B /* HexColorsTests.swift in Sources */,
+				47B65C552C82660700F8076B /* ButtonViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bracquet/Utils/Styles.swift
+++ b/Bracquet/Utils/Styles.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 // Application Colors
-class BraquetColors {
-    static let pureBlack: String = "#000000"
-    static let pureWhite: String = "#FFFFFF"
-    static let backgroundWhite: String = "#EBEBEB"
-    static let primaryBlue: String = "#6699CC"
-    static let primaryGreen: String = "#A6C954"
-    static let accentGray: String = "565554"
-    static let accentBlack: String = "363B44"
+enum BraquetColors: String {
+    case pureBlack = "#000000"
+    case pureWhite = "#FFFFFF"
+    case backgroundWhite = "#EBEBEB"
+    case primaryBlue = "#6699CC"
+    case primaryGreen = "#A6C954"
+    case accentGray = "565554"
+    case accentBlack = "363B44"
 }

--- a/Bracquet/Views/ButtonView.swift
+++ b/Bracquet/Views/ButtonView.swift
@@ -1,0 +1,55 @@
+//  ButtonView.swift
+//  Copyright Bracquet 2024
+//
+//  This view component contains the app's standard button.
+//  The button supports all Bracquet app colors and is written
+//  to accept any closure as a callback.
+//
+//  Created by Drew Curtin on 8/27/24.
+
+import SwiftUI
+
+struct ButtonView: View {
+    // Props
+    let text: String
+    let color: BraquetColors
+    let tapCallback: () -> Void
+    
+    // Constructors - @escaping is required because the function closure will be called
+    // after the constructor returns.
+    init(text: String, color: BraquetColors, tapCallback: @escaping () -> Void) {
+        self.text = text
+        self.color = color
+        self.tapCallback = tapCallback
+    }
+    
+    var body: some View {
+        Button(action: tapCallback) {
+            HStack() {
+                Spacer()
+                
+                Text(self.text)
+                    .font(Font.custom("Inter-SemiBold", size: 24))
+                    .foregroundColor(Color(hex: BraquetColors.pureBlack.rawValue))
+                
+                Spacer()
+            }
+            .frame(height: 50)
+            .background(Color(hex: self.color.rawValue))
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color(hex: BraquetColors.accentBlack.rawValue), lineWidth: 3)
+            )
+            .padding([.leading, .trailing], 15)
+        }
+    }
+}
+
+struct ButtonView_Previews: PreviewProvider {
+    static var previews: some View {
+        ButtonView(text: "Click Here!", color: BraquetColors.primaryBlue) {
+            print("Callback passed!");
+        }
+    }
+}

--- a/Bracquet/Views/HeaderView.swift
+++ b/Bracquet/Views/HeaderView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct HeaderView: View {
     var body: some View {
         HStack() {
-
             Image("Bracquet Icon")
                 .padding(.leading, 25)
             
@@ -19,7 +18,7 @@ struct HeaderView: View {
             
             Text("Bracquet")
                 .font(Font.custom("Inter-Bold", size: 60))
-                .foregroundColor(Color(hex: BraquetColors.pureBlack))
+                .foregroundColor(Color(hex: BraquetColors.pureBlack.rawValue))
                 .padding(.trailing, 25)
         }
     }


### PR DESCRIPTION
**BRAC-3:** This commit contains a reusable button view component, as well as a suite of unit tests for it. The button has been designed to support any app color, and it takes a closure as an input to allow its tap gesture callback to be customized.

**Qualification:** Locally ran all unit tests for the project - All passed